### PR TITLE
Only set the seed in random_from_pdf if supplied

### DIFF
--- a/core/fnss/util.py
+++ b/core/fnss/util.py
@@ -71,7 +71,8 @@ def random_from_pdf(pdf, seed=None):
         raise ValueError('The parameter pdf must be a dictionary')
     if abs(sum(pdf.values()) - 1) > 0.0001:
         raise ValueError('The sum of all probabilities must be equal to 1')
-    random.seed(seed)
+    if seed:
+        random.seed(seed)
     r = random.random()
     w = 0.0
     for key, value in pdf.items():


### PR DESCRIPTION
Previously, random_from_pdf would always set the seed to None. This made it impossible to reproduce glp_toplogies with a non-None seed, since glp_topology doesn't pass its supplied seed to random_from_pdf.

This fixes that issue (and potentially other similar issues) by only setting the seed in random_from_pdf if it is supplied.
