### PR TITLE
distutils deprecated and removed -- looseversion replaces functionality

### DIFF
--- a/fnss/netconfig/capacities.py
+++ b/fnss/netconfig/capacities.py
@@ -3,7 +3,7 @@
 Link capacities can be assigned either deterministically or randomly, according
 to various models.
 """
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 
 import networkx as nx
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ sphinx_rtd_theme
 
 # Packaging
 wheel
+looseversion

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,3 @@ sphinx_rtd_theme
 
 # Packaging
 wheel
-looseversion

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ from setuptools import setup, find_packages
 requires = [
     'networkx (>=2.0)',
     'numpy (>=1.4)',
-    'mako (>=0.4)'
+    'mako (>=0.4)',
+    'looseversion (>=1.3.0)'
 ]
 
 # It imports release module this way because if it tried to import fnss package


### PR DESCRIPTION
This may be of value to versions running after distutils was deprecated and removed.